### PR TITLE
Log the error TF_REPEATED_DATA as debug instead of warn

### DIFF
--- a/geometry2/package.xml
+++ b/geometry2/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>geometry2</name>
-  <version>0.7.7</version>
+  <version>0.7.8</version>
   <description>
     A metapackage to bring in the default packages second generation Transform Library in ros, tf2.
   </description>

--- a/test_tf2/package.xml
+++ b/test_tf2/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>test_tf2</name>
-  <version>0.7.7</version>
+  <version>0.7.8</version>
   <description>
     tf2 unit tests
   </description>

--- a/tf2/package.xml
+++ b/tf2/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>tf2</name>
-  <version>0.7.7</version>
+  <version>0.7.8</version>
   <description>
     tf2 is the second generation of the transform library, which lets
     the user keep track of multiple coordinate frames over time. tf2

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -276,7 +276,14 @@ bool BufferCore::setTransform(const geometry_msgs::TransformStamped& transform_i
     }
     else
     {
-      CONSOLE_BRIDGE_logWarn((error_string+" for frame %s (parent %s) at time %lf according to authority %s").c_str(), stripped.child_frame_id.c_str(), stripped.header.frame_id.c_str(), stripped.header.stamp.toSec(), authority.c_str());
+      if(error_string != std::string("TF_REPEATED_DATA ignoring data with redundant timestamp"))
+      {
+        CONSOLE_BRIDGE_logWarn((error_string+" for frame %s (parent %s) at time %lf according to authority %s").c_str(), stripped.child_frame_id.c_str(), stripped.header.frame_id.c_str(), stripped.header.stamp.toSec(), authority.c_str());
+      }
+      else
+      {
+        CONSOLE_BRIDGE_logDebug((error_string+" for frame %s (parent %s) at time %lf according to authority %s").c_str(), stripped.child_frame_id.c_str(), stripped.header.frame_id.c_str(), stripped.header.stamp.toSec(), authority.c_str());
+      }
       return false;
     }
   }

--- a/tf2_bullet/package.xml
+++ b/tf2_bullet/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>tf2_bullet</name>
-  <version>0.7.7</version>
+  <version>0.7.8</version>
   <description>
     tf2_bullet
   </description>

--- a/tf2_eigen/package.xml
+++ b/tf2_eigen/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>tf2_eigen</name>
-  <version>0.7.7</version>
+  <version>0.7.8</version>
   <description>tf2_eigen</description>
   <author>Koji Terada</author>
   <maintainer email="terakoji@gmail.com">Koji Terada</maintainer>

--- a/tf2_geometry_msgs/package.xml
+++ b/tf2_geometry_msgs/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>tf2_geometry_msgs</name>
-  <version>0.7.7</version>
+  <version>0.7.8</version>
   <description>
     tf2_geometry_msgs
   </description>

--- a/tf2_kdl/package.xml
+++ b/tf2_kdl/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>tf2_kdl</name>
-  <version>0.7.7</version>
+  <version>0.7.8</version>
   <description>
     KDL binding for tf2
   </description>

--- a/tf2_msgs/package.xml
+++ b/tf2_msgs/package.xml
@@ -1,7 +1,7 @@
 <package>
 
   <name>tf2_msgs</name>
-  <version>0.7.7</version>
+  <version>0.7.8</version>
   <description>
     tf2_msgs
   </description>

--- a/tf2_py/package.xml
+++ b/tf2_py/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>tf2_py</name>
-  <version>0.7.7</version>
+  <version>0.7.8</version>
   <description>The tf2_py package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag --> 

--- a/tf2_ros/package.xml
+++ b/tf2_ros/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>tf2_ros</name>
-  <version>0.7.7</version>
+  <version>0.7.8</version>
   <description>
     This package contains the ROS bindings for the tf2 library, for both Python and C++.
   </description>

--- a/tf2_sensor_msgs/package.xml
+++ b/tf2_sensor_msgs/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>tf2_sensor_msgs</name>
-  <version>0.7.7</version>
+  <version>0.7.8</version>
   <description>
     Small lib to transform sensor_msgs with tf. Most notably, PointCloud2
   </description>

--- a/tf2_tools/package.xml
+++ b/tf2_tools/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>tf2_tools</name>
-  <version>0.7.7</version>
+  <version>0.7.8</version>
   <description>
     tf2_tools
   </description>


### PR DESCRIPTION
This is to avoid the excessive spam in the terminal when it happens, specially when working with Gazebo.